### PR TITLE
Fix chat send errors, add message validation, and improve Action Cable production config

### DIFF
--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -15,11 +15,11 @@ class ChatroomsController < ApplicationController
   end
 
   def show
-    @activity = Activity.find(params[:id])
+    @chatroom = Chatroom.includes(:activity).find(params[:id])
+    @activity = @chatroom.activity
     @activities_booked = current_user.bookings.where(status: true)
     # looking for the booking of the current user that is approved and has the activity of the current page
     @activity_booked = @activities_booked.find_by(activity_id: @activity.id)
-    @chatroom = @activity.chatroom
     @message = Message.new
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,9 +1,12 @@
 class MessagesController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     @chatroom = Chatroom.find(params[:chatroom_id])
     @message = Message.new(message_params)
     @message.chatroom = @chatroom
     @message.user = current_user
+
     if @message.save
       ChatroomChannel.broadcast_to(
         @chatroom,
@@ -12,7 +15,7 @@ class MessagesController < ApplicationController
       )
       head :ok
     else
-      render "activities/show", status: :unprocessable_entity
+      render json: { errors: @message.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,8 @@ class Message < ApplicationRecord
   belongs_to :chatroom
   belongs_to :user
 
+  validates :content, presence: true
+
   def sender?(a_user)
     user.id == a_user.id
   end

--- a/app/views/chatrooms/_chatroom.html.erb
+++ b/app/views/chatrooms/_chatroom.html.erb
@@ -16,6 +16,8 @@
     <% end %>
   </div>
 
+  <p class="text-danger d-none mb-2" data-chatroom-subscription-target="formError"></p>
+
   <div class="d-flex chat-input">
     <%= simple_form_for [chatroom, message],
       html: { data: { action: "turbo:submit-end->chatroom-subscription#resetForm" }, class: "d-flex" } do |f| %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,8 +43,11 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.url = ENV.fetch("ACTION_CABLE_URL", "wss://#{ENV.fetch("HEROKU_APP_NAME", "senioren-all-tag-plus-c79d436cda54")}.herokuapp.com/cable")
+  config.action_cable.allowed_request_origins = [
+    /https:\/\/.*\.herokuapp\.com/,
+    ENV["APP_HOST"]
+  ].compact
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/spec/controllers/chatrooms_controller_spec.rb
+++ b/spec/controllers/chatrooms_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ChatroomsController, type: :controller do
+  describe 'GET #show' do
+    let(:user) { create(:user) }
+    let(:chatroom) { create(:chatroom) }
+
+    before { sign_in user }
+
+    it 'loads chatroom and its activity by chatroom id' do
+      get :show, params: { id: chatroom.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:chatroom)).to eq(chatroom)
+      expect(assigns(:activity)).to eq(chatroom.activity)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,6 +5,27 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker::Internet.unique.email }
-    password { "123456" }
+    password { '123456' }
+  end
+
+  factory :category do
+    name { 'Fitness' }
+  end
+
+  factory :activity do
+    association :category
+    association :owner, factory: :user
+
+    name { 'Morning Walk' }
+    address { 'Berlin' }
+    date_time { 2.days.from_now }
+    description { 'Group walk in the park' }
+    difficulty { 2 }
+    equipment { 'Comfortable shoes' }
+    max_count { 10 }
+  end
+
+  factory :chatroom do
+    association :activity
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  subject(:message) { described_class.new(chatroom: create(:chatroom), user: create(:user), content: 'Hello') }
+
+  it { is_expected.to validate_presence_of(:content) }
+end


### PR DESCRIPTION
### Motivation
- The chat was failing in production when users submitted messages due to brittle lookups, missing validation handling, and unhelpful error rendering. 
- Action Cable required more robust production defaults for Heroku to ensure websocket connections are routed correctly.
- The frontend needed better handling of submit failures so users see validation errors instead of the app erroring.

### Description
- Load the `Chatroom` by `params[:id]` in `ChatroomsController#show` and derive the associated `Activity` from the chatroom to avoid ID mismatch issues (`app/controllers/chatrooms_controller.rb`).
- Enforce authentication for message creation, add structured JSON error responses on save failures, and stop rendering unrelated pages on failure in `MessagesController#create` (`app/controllers/messages_controller.rb`).
- Add a presence validation for `Message#content` so empty messages are rejected at the model level (`app/models/message.rb`).
- Improve the Stimulus controller to only reset the form on successful submits, parse and display backend validation errors in the UI, and safely unsubscribe from Action Cable (`app/javascript/controllers/chatroom_subscription_controller.js`).
- Add an inline error placeholder to the chatroom partial to show form errors (`app/views/chatrooms/_chatroom.html.erb`) and add production Action Cable defaults with a Heroku-friendly `ACTION_CABLE_URL` fallback and allowed origins (`config/environments/production.rb`).
- Add/expand test factories and two focused specs for `ChatroomsController#show` and `Message` validation (`spec/factories.rb`, `spec/controllers/chatrooms_controller_spec.rb`, `spec/models/message_spec.rb`).

### Testing
- Ran Ruby syntax checks with `ruby -c` for `app/controllers/chatrooms_controller.rb`, `app/controllers/messages_controller.rb`, and `app/models/message.rb`, which all returned OK.
- Attempted to run the new specs with `bundle exec rspec spec/models/message_spec.rb spec/controllers/chatrooms_controller_spec.rb` but the run was blocked by environment issues (Ruby version mismatch with the `Gemfile` and Bundler/gem fetch errors), so specs could not be executed in CI here.
- `bundle install` failed in this environment due to a Bundler version/lock mismatch and remote gem fetch errors, preventing local test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fdb0833883279ba2a60fa03f0c42)