### PR TITLE
Add root case-study.json for portfolio integration

### DIFF
--- a/case-study.json
+++ b/case-study.json
@@ -1,0 +1,42 @@
+{
+  "title": "SeniorenAllTagPlus",
+  "pitch": "A bridge between generations, connecting seniors with peers and compassionate volunteers while providing practical day-to-day support services.",
+  "target": "Elderly individuals affected by loneliness.",
+  "problem": "Loneliness and limited access to approachable digital support tools for seniors.",
+  "solution": "A simple, senior-friendly platform that connects seniors and volunteers while offering helpful daily-life services.",
+  "role": "Team Lead (group project of 4)",
+  "contributions": [
+    "Led project planning and task breakdown",
+    "Reviewed and merged code changes",
+    "Contributed across frontend and backend implementation",
+    "Coordinated team communication and delivery"
+  ],
+  "techStack": [
+    "Ruby on Rails",
+    "Devise",
+    "PostgreSQL (prod) / SQLite (dev)",
+    "Heroku"
+  ],
+  "features": [
+    "User authentication and account management with Devise",
+    "Activity discovery and management with category-based organization",
+    "Booking flow for joining activities, including accept/decline states",
+    "Dashboard view for tracking user activities and bookings",
+    "Real-time chatrooms and messaging for participant communication",
+    "Map-based activity context using geocoded locations"
+  ],
+  "architecture": "Rails MVC with Devise authentication and ActiveRecord persistence.",
+  "challenges": [
+    "Designing an accessible, simple UX for non-technical users",
+    "Coordinating concurrent team changes and resolving merge conflicts",
+    "Implementing authentication and permission-sensitive flows safely",
+    "Deploying reliably on Heroku with environment-specific configuration"
+  ],
+  "results": [
+    "TBD (add real metrics later)"
+  ],
+  "links": {
+    "demo": "https://senioren-all-tag-plus-c79d436cda54.herokuapp.com/",
+    "repo": "https://github.com/ardidrizi/SeniorenAllTagPlus"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a repository-root `case-study.json` that the portfolio can consume with professional, non-speculative wording for project metadata.
- Surface concrete app capabilities (auth, activities, bookings, dashboard, chat, map) so the case study aligns with the existing codebase.

### Description
- Added `case-study.json` at the repository root containing the requested fields (`title`, `pitch`, `target`, `problem`, `solution`, `role`, `contributions`, `techStack`, `features`, `architecture`, `challenges`, `results`, and `links`).
- Refined phrasing to be professional and avoided invented metrics, and populated `features` from functionality observed in the app (Devise auth, activity management, bookings flow, dashboard, chatrooms, geocoded locations).
- Included demo and repository URLs in the `links` object to make the case study immediately usable by portfolio tooling.

### Testing
- Verified JSON validity with `jq empty case-study.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a106c091f48327a713cd6f3326fb1d)