### PR TITLE
Add public homepage and protected activities preview for logged-out users

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,7 +1,10 @@
 class ActivitiesController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index show]
   before_action :set_activity, only: [:show]
 
   def index
+    return public_index if user_signed_out?
+
     if params[:tag].present?
       @category_id = Category.find_by(name: params[:tag]).id
       @activities = Activity.where(category_id: @category_id)
@@ -21,6 +24,8 @@ class ActivitiesController < ApplicationController
   end
 
   def show
+    return public_show if user_signed_out?
+
     @activity = Activity.find(params[:id])
     @markers = geocoded_activity_markers(@activity)
     @booking = Booking.new
@@ -82,6 +87,18 @@ class ActivitiesController < ApplicationController
     end
   end
 
+  def public_index
+    @activities = Activity.where(public: true).includes(:category).order(date_time: :asc)
+    render :public_index
+  end
+
+  def public_show
+    @activity = Activity.includes(:category).find_by(id: params[:id], public: true)
+    return redirect_to new_user_session_path unless @activity
+
+    render :public_show
+  end
+
   private
 
   def activity_params
@@ -92,6 +109,7 @@ class ActivitiesController < ApplicationController
   def set_activity
     @activity = Activity.find_by(id: params[:id])
   end
+
 
   def geocoded_activity_markers(activity)
     return [] unless activity.present?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+class HomeController < ApplicationController
+  skip_before_action :authenticate_user!, only: :index
+
+  def index
+  end
+end

--- a/app/views/activities/public_index.html.erb
+++ b/app/views/activities/public_index.html.erb
@@ -1,0 +1,24 @@
+<section class="py-3">
+  <h1 class="section-title">Public activities preview</h1>
+  <p>Discover sample activities available in your area.</p>
+</section>
+
+<div class="col-12">
+  <% @activities.each do |activity| %>
+    <%= link_to activity_path(activity), class: "text-decoration-none" do %>
+      <div class="custom--card">
+        <div class="pb-2 px-2">
+          <h4 class="my-1 mt-2 mb-0 section-title"><%= activity.name %></h4>
+          <h5 class="pb-0 mt-1"><%= activity.category.name %></h5>
+          <h6 class="pb-0 mt-1"><%= activity.date_time.strftime('%^a, %d %^b, %Y at %H:%M') %></h6>
+          <h6 class="mt-1"><%= activity.address.to_s.split(',').first %></h6>
+          <p class="mb-2"><%= truncate(activity.description, length: 120) %></p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="mt-3">
+  <%= link_to "Create or Join activities", new_user_registration_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/activities/public_show.html.erb
+++ b/app/views/activities/public_show.html.erb
@@ -1,0 +1,11 @@
+<section class="py-3">
+  <h1 class="section-title"><%= @activity.name %></h1>
+  <h5><%= @activity.category.name %></h5>
+  <p><strong>Date and time:</strong> <%= @activity.date_time.strftime('%^a, %d %^b, %Y at %H:%M') %></p>
+  <p><strong>Approximate location:</strong> <%= @activity.address.to_s.split(',').first %></p>
+  <p><%= @activity.description %></p>
+</section>
+
+<div class="mt-3">
+  <%= link_to "Create or Join activities", new_user_registration_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,32 @@
+<section class="py-4 text-center">
+  <h1 class="section-title">SeniorenAllTagPlus</h1>
+  <p class="lead">Find local activities, stay connected, and enjoy safe social moments every week.</p>
+  <div class="d-flex justify-content-center gap-2 mt-3">
+    <%= link_to "Sign up", new_user_registration_path, class: "btn btn-primary" %>
+    <%= link_to "Login", new_user_session_path, class: "btn btn-outline-primary" %>
+  </div>
+</section>
+
+<section id="how-it-works" class="py-4">
+  <h2 class="section-title">How it works</h2>
+  <ol>
+    <li>Browse activities by category and date.</li>
+    <li>Create your own activity or request to join one.</li>
+    <li>Meet safely with your local community.</li>
+  </ol>
+</section>
+
+<section class="py-4">
+  <h2 class="section-title">Preview activities</h2>
+  <p>Take a look at upcoming public activities before creating your account.</p>
+  <%= link_to "View activities", activities_path, class: "btn btn-info" %>
+</section>
+
+<footer class="py-4 border-top mt-4">
+  <div class="d-flex flex-wrap gap-3">
+    <%= link_to "About", root_path %>
+    <%= link_to "How it works", "#how-it-works" %>
+    <%= link_to "Safety", root_path %>
+    <%= link_to "Contact", root_path %>
+  </div>
+</footer>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to activities_path, class: "navbar-brand d-flex align-items-center gap-2" do %>
+    <%= link_to root_path, class: "navbar-brand d-flex align-items-center gap-2" do %>
       <%= image_tag "logo.png", class: "navbar-logo", alt: "SeniorenAllTagPlus logo" %>
       <span class="brand-text">SeniorenAllTagPlus</span>
     <% end %>
@@ -9,15 +9,28 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item">
-          <%= link_to "Activities", activities_path, class: "nav-link" %>
-        </li>
         <% if user_signed_in? %>
+          <li class="nav-item">
+            <%= link_to "Activities", activities_path, class: "nav-link" %>
+          </li>
           <li class="nav-item">
             <%= link_to "Dashboard", dashboard_path, class: "nav-link" %>
           </li>
           <li class="nav-item">
             <%= link_to "Messages", chatrooms_path, class: "nav-link" %>
+          </li>
+        <% else %>
+          <li class="nav-item">
+            <%= link_to "Home", root_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Activities", activities_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "How it works", "#{root_path}#how-it-works", class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Safety", root_path, class: "nav-link" %>
           </li>
         <% end %>
       </ul>
@@ -46,7 +59,7 @@
             </ul>
           </div>
         <% else %>
-          <%= link_to "Sign in", new_user_session_path, class: "btn btn-outline-light btn-nav nav-pill" %>
+          <%= link_to "Login", new_user_session_path, class: "btn btn-outline-light btn-nav nav-pill" %>
           <%= link_to "Sign up", new_user_registration_path, class: "btn btn-primary btn-nav nav-pill" %>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,14 @@
 Rails.application.routes.draw do
   devise_for :users
-  # root to: "pages#home"
-  root to: 'activities#index'
+
+  authenticated :user do
+    root to: 'activities#index', as: :authenticated_root
+  end
+
+  unauthenticated do
+    root to: 'home#index'
+  end
+
   resources :activities do
     resources :bookings, only: %i[create]
   end
@@ -18,5 +25,4 @@ Rails.application.routes.draw do
     resources :messages, only: :create
   end
   get 'activities/:id/details', to: 'activities#show_details', as: 'activity_details'
-
 end

--- a/db/migrate/20260303000000_add_public_to_activities.rb
+++ b/db/migrate/20260303000000_add_public_to_activities.rb
@@ -1,0 +1,5 @@
+class AddPublicToActivities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :activities, :public, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_30_112058) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_30_112058) do
     t.float "latitude"
     t.float "longitude"
     t.integer "max_count"
+    t.boolean "public", default: false, null: false
     t.index ["category_id"], name: "index_activities_on_category_id"
     t.index ["owner_id"], name: "index_activities_on_owner_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,6 +23,11 @@ FactoryBot.define do
     difficulty { 2 }
     equipment { 'Comfortable shoes' }
     max_count { 10 }
+    public { false }
+
+    trait :public_preview do
+      public { true }
+    end
   end
 
   factory :chatroom do

--- a/spec/requests/public_access_spec.rb
+++ b/spec/requests/public_access_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Public access', type: :request do
+  let!(:category) { create(:category, name: 'Wellness') }
+  let!(:owner) { create(:user, email: 'owner@example.com') }
+  let!(:public_activity) do
+    create(:activity, :public_preview,
+           category: category,
+           owner: owner,
+           name: 'Park Yoga',
+           address: 'Berlin, Mitte',
+           description: 'Gentle outdoor movement')
+  end
+  let!(:private_activity) { create(:activity, category: category, owner: owner, public: false, name: 'Private Walk') }
+
+  describe 'GET /' do
+    it 'returns 200 for logged out users' do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('How it works')
+    end
+  end
+
+  describe 'GET /activities' do
+    it 'returns 200 for logged out users' do
+      get activities_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Public activities preview')
+      expect(response.body).to include(public_activity.name)
+      expect(response.body).not_to include(private_activity.name)
+    end
+  end
+
+  describe 'GET /activities/:id' do
+    it 'returns 200 for a public activity when logged out' do
+      get activity_path(public_activity)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(public_activity.name)
+      expect(response.body).to include('Create or Join activities')
+    end
+
+    it 'redirects to login for a private activity when logged out' do
+      get activity_path(private_activity)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'private areas' do
+    it 'redirects logged out users to login' do
+      get dashboard_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'privacy on public pages' do
+    it 'does not expose user email or phone-like values' do
+      get activities_path
+
+      expect(response.body).not_to include(owner.email)
+      expect(response.body).not_to match(/\+?\d[\d\s\-]{7,}/)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide a public landing experience for logged-out visitors while keeping private user data and private activities protected. 
- Let unauthenticated users browse a safe preview of activities and encourage signup via clear CTAs without exposing contact or participant details. 

### Description
- Added `HomeController#index` and a public landing view with headline, subheadline, Sign up/Login CTAs, a three-step "How it works" section, "Preview activities" link, and footer links. 
- Updated routing so authenticated users keep `activities#index` as the root and unauthenticated users are routed to `home#index`. 
- Made `ActivitiesController#index` and `show` available to logged-out users by adding `skip_before_action :authenticate_user!` and routing logged-out requests to safe `public_index`/`public_show` handlers that only return activities with `public: true`. 
- Added public views `app/views/activities/public_index.html.erb` and `app/views/activities/public_show.html.erb` that only display safe fields (title, category, date/time, approximate location, short description) and include a "Create or Join activities" CTA linking to signup. 
- Updated the navbar for logged-out users to include Home, Activities, How it works, Safety, Login, and Sign up while preserving logged-in navigation. 
- Introduced a migration `AddPublicToActivities` to add a `public` boolean to `activities`, updated `db/schema.rb`, added a `:public_preview` factory trait, and added request specs to validate public/private behavior. 

### Testing
- Added request specs `spec/requests/public_access_spec.rb` that assert `GET /` returns 200 for logged out users, `GET /activities` returns public activities only, `GET /activities/:id` serves public activities and blocks private ones, private pages redirect to login, and public pages do not leak emails/phone-like values. 
- Attempted to run database migrations with `bundle exec rails db:migrate` and `bin/rails db:migrate`, but both failed in this environment (`bundler: command not found: rails` and a Ruby version mismatch between runtime `3.2.3` and the `Gemfile` `3.1.2`), so migrations and specs were not executed here. 
- Attempted a Playwright page screenshot to validate rendering, but the headless Chromium run crashed in this environment (SIGSEGV), so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a654a5dcc48327894af2cfea43a566)